### PR TITLE
fix: Replace command for checking spheron installation via version instead of help

### DIFF
--- a/pages/user-guide/deploy-your-app.mdx
+++ b/pages/user-guide/deploy-your-app.mdx
@@ -23,7 +23,7 @@ curl -sL1 https://sphnctl.sh | bash
 
 ```sh
 # Verify the installation by using a simple command to check the Spheron version
-sphnctl -h
+sphnctl version
 ```
 
 ### Step 2: Create a new wallet using the CLI


### PR DESCRIPTION
For seeing the version the command is:
```bash
sphnctl version
```
![image](https://github.com/user-attachments/assets/c492c0ec-5dbe-456f-bf25-da3164d6dc0b)
But in the docs, the command is given for help.

Docs link: https://docs.spheron.network/user-guide/protocol-cli#install-spheron-protocol-cli