### PR TITLE
Hide broken community link from navbar

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -13,10 +13,10 @@ const config: DocsThemeConfig = {
     link: "https://github.com/spheronFdn/docs",
     icon: <div className={styles.linkIcon}>{GithubLogo}</div>,
   },
-  chat: {
-    link: "https://community.spheron.network/",
-    icon: <div className={styles.linkIcon}>{CommunityLogo}</div>,
-  },
+  // chat: {
+  //   link: "https://community.spheron.network/",
+  //   icon: <div className={styles.linkIcon}>{CommunityLogo}</div>,
+  // },
   editLink: {
     text: null,
   },


### PR DESCRIPTION
<img width="298" alt="image" src="https://github.com/user-attachments/assets/c0521385-038a-4873-a4d8-88864cd9d30d">
